### PR TITLE
Keyword 영어로 번역해서 prompt에 반영

### DIFF
--- a/src/components/api/TranslateSettings.tsx
+++ b/src/components/api/TranslateSettings.tsx
@@ -39,7 +39,11 @@ async function TranslateSetting(setting: Setting | null) {
   }
   console.log(random_keywords);
 
-  const prompt = "Generate a "+ word_num + "-word " + setting.format + "which has lexile level " + setting.li.toString() + "and title flanked by < and >. The text should contain the following words in English: " + setting.keywords.join(", ") + ", " + random_keywords.join(", ") + "."
+  const keyword_list = setting.keywords.concat(random_keywords);
+  const translate_keyword = "Translate the following keywords in Korean into English. Do not answer anything else than the keywords. Seperate the keywords with a single comma(,). " + keyword_list.join(", ");
+  const translated_keywords = await prompts(translate_keyword);
+
+  const prompt = "Generate a "+ word_num + "-word " + setting.format + "which has lexile level " + setting.li.toString() + "and title flanked by < and >. The text should contain the following words in English: " + translated_keywords + "."
 
   const prompt_result = await prompts(prompt);
   return parse(prompt_result);


### PR DESCRIPTION
keyword를 사전에 영어로 번역한 뒤 프롬프트에 반영하도록 수정했습니다. 테스팅했을 때에는 더 이상 한국어 키워드가 번역되지 않는 것을 확인했습니다.